### PR TITLE
2016 -> 2017

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -12,7 +12,7 @@
     = csrf_meta_tags
 
     %meta{content: "http://rockymtnruby.com/", property: "og:url"}
-    %meta{content: "Rocky Mountain Ruby 2016", property: "og:title"}
+    %meta{content: "Rocky Mountain Ruby 2017", property: "og:title"}
     %meta{content: "Rocky Mountain Ruby is back for the seventh year, bringing together 250 developers in downtown Denver. Attendees will hear from nine industry leaders as we share practices and build our community.", property: "og:description"}
     %meta{content: "Rocky Mountain Ruby", property: "og:site_name"}
     %meta{content: "http://rockymtnruby.com/small-denver.jpg", property: "og:image"}

--- a/app/views/layouts/mailer.html.haml
+++ b/app/views/layouts/mailer.html.haml
@@ -146,7 +146,7 @@
                                         %td{:height => "5", :style => "font-size: 1px; line-height: 1px;"}  
                                       %tr
                                         %td.fullCenter{:align => "center", :style => "text-align: left; font-size: 13px; color: #ffffff; font-family: Helvetica, Arial, sans-serif, 'Open Sans'; line-height: 22px; vertical-align: top; font-weight: 400;", :width => "100%"}
-                                          © 2016 All rights Reserved
+                                          © 2017 All rights Reserved
                                       %tr
                                         %td{:height => "5", :style => "font-size: 1px; line-height: 1px;"}  
                                       %tr


### PR DESCRIPTION
I noticed that the link showed 2016 when I shared it on slack

![image](https://user-images.githubusercontent.com/987305/26859981-8e6bfa3e-4af8-11e7-8ae5-740e941cb8f3.png)

So I fixed the og:title meta tag & copyright on a mailer layout.  There were a couple other instances of 2016 in the code base but these were the most obvious changes

---

For those too young to get my branch name reference: https://www.youtube.com/watch?v=hwK_WOXjfc0